### PR TITLE
Custom Consistent Step Layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ const MyStep = (props) =>
 #### Components
 ### WhateverWizard
 ##### Props
-#### `scopekey`: string Default: wizard
+#### `scopeKey`: string Default: wizard
 Key to nest step props for component. Used by `layoutComponent` and `componentClass`.
 
 #### `layoutComponent`: `class`, `React.createComponent`, `function`

--- a/README.md
+++ b/README.md
@@ -49,20 +49,26 @@ const MyStep = (props) =>
 #### Components
 ### WhateverWizard
 ##### Props
-#### `scopeKey`: string Default: wizard
-Key to nest step props for component. Used by `layoutComponent` and `componentClass`.
+#### `scopeKey`: `string` Default: wizard
+Key to nest wizard specific props for the `layoutComponent` and `componentClass` components.
 
 #### `layoutComponent`: `class`, `React.createComponent`, `function`
 The layout that renders with each step. Where buttons should be placed, progress bar, step number, etc.
-Is effected by `scopeKey`.
+Not effected by `scopeKey`.
+
+#### `layoutProps`: `object`
+Props to pass to the `layoutComponent`. Not effected by `scopeKey`.
 
 ### Step
 ##### Props
 #### `componentClass`: `class`, `React.createComponent`, `function`
 The component to render for that step. This component will receive wizard props under the `scopeKey`.
 
-#### `componentProps`: `object` of props for `componentClass`
-The props for the component.
+#### `componentProps`: `object`
+The props for `componentClass`. Not effected by `scopeKey`.
+
+#### `layoutProps`: `object`
+Props to pass to the `layoutComponent`. `Step` specific `layoutProps` will override the parent `WhateverWizard` `layoutProps`. Not effected by `scopeKey`.
 
 ### StepButton
 Currently, there is no `onClick` for `StepButton`, not through the Component itself nor `componentProps`.

--- a/README.md
+++ b/README.md
@@ -50,12 +50,19 @@ const MyStep = (props) =>
 ### WhateverWizard
 ##### Props
 #### `scopekey`: string Default: wizard
-Key to nest step props for component.
+Key to nest step props for component. Used by `layoutComponent` and `componentClass`.
+
+#### `layoutComponent`: `class`, `React.createComponent`, `function`
+The layout that renders with each step. Where buttons should be placed, progress bar, step number, etc.
+Is effected by `scopeKey`.
 
 ### Step
 ##### Props
 #### `componentClass`: `class`, `React.createComponent`, `function`
+The component to render for that step. This component will receive wizard props under the `scopeKey`.
+
 #### `componentProps`: `object` of props for `componentClass`
+The props for the component.
 
 ### StepButton
 Currently, there is no `onClick` for `StepButton`, not through the Component itself nor `componentProps`.

--- a/src/Example.js
+++ b/src/Example.js
@@ -2,16 +2,23 @@ import React, { Component } from 'react';
 import './Example.css';
 import { WhateverWizard, Step, StepButton } from './WhateverWizard';
 
+const Layout = props =>
+  <div>
+    <h3>Step {props.wizard.number} of {props.wizard.total}</h3>
+    <h4>{props.title}</h4>
+    {props.wizard.buttons}
+    <hr/>
+    {props.children}
+  </div>
+
 const SomeStep = (props) =>
   <div style={{color: props.color || 'black'}}>
-    <h1>Step {props.wizard.number}</h1>
     <p>This is a step</p>
     <p>Last step? {String(props.wizard.isLast)}</p>
   </div>;
 
 const AnotherStep = (props) =>
   <div>
-    <h1>Step {props.wizard.number} / {props.wizard.total}</h1>
     <p>This is another step</p>
     <p>Actions available: {Object.keys(props.wizard.actions).join(', ')}</p>
     <button onClick={props.wizard.actions.first}>Restart</button>
@@ -22,7 +29,7 @@ class Example extends Component {
     return (
       <div className="Example">
         <h1>WhateverWizard</h1>
-        <WhateverWizard>
+        <WhateverWizard layoutComponent={Layout} layoutProps={{title: 'Enter Data'}}>
           <Step componentClass={SomeStep} componentProps={{color: 'slateblue'}}>
             <StepButton
               preRole={() => alert('welcome to help')}
@@ -32,8 +39,7 @@ class Example extends Component {
             <StepButton role="next">Next</StepButton>
             <StepButton role="last">Skip All</StepButton>
           </Step>
-          <Step componentClass={AnotherStep}>
-            <span>?</span>
+          <Step componentClass={AnotherStep} layoutProps={{title: 'Customize Data'}}>
             <StepButton role="back">Back</StepButton>
             <StepButton role="next" preRole={() => confirm('go')}>Proceed</StepButton>
           </Step>

--- a/src/Example.js
+++ b/src/Example.js
@@ -33,6 +33,7 @@ class Example extends Component {
             <StepButton role="last">Skip All</StepButton>
           </Step>
           <Step componentClass={AnotherStep}>
+            <span>?</span>
             <StepButton role="back">Back</StepButton>
             <StepButton role="next" preRole={() => confirm('go')}>Proceed</StepButton>
           </Step>

--- a/src/WhateverWizard.js
+++ b/src/WhateverWizard.js
@@ -6,12 +6,13 @@ const _e = () => {};
 
 const BasicLayout = props =>
   (<div>
-    <h4>Each Step Has the Same layout {props.title}</h4>
     {props[props.scopeKey].number} / {props[props.scopeKey].total}
     <hr/>
     {props.children}
     <hr/>
-    {props[props.scopeKey].buttons}
+    <nav>
+      {props[props.scopeKey].buttons}
+    </nav>
   </div>);
 
 function StateManager(Component) {

--- a/src/WhateverWizard.js
+++ b/src/WhateverWizard.js
@@ -6,12 +6,12 @@ const _e = () => {};
 
 const BasicLayout = props =>
   (<div>
-    <h4>Complete These Steps</h4>
+    <h4>Each Step Has the Same layout {props.title}</h4>
+    {props[props.scopeKey].number} / {props[props.scopeKey].total}
     <hr/>
     {props.children}
     <hr/>
-    {props.wizard.number} / {props.wizard.total}
-    {props.wizard.buttons}
+    {props[props.scopeKey].buttons}
   </div>);
 
 function StateManager(Component) {
@@ -173,6 +173,8 @@ export class Step extends React.Component {
         number,
       },
       layoutComponent: Layout,
+      layoutProps,
+      parentLayoutProps,
       wizardStateManager,
       wizardStateManager: {
         actions,
@@ -200,12 +202,16 @@ export class Step extends React.Component {
       }
     }))
 
-    const propsToLayout = { actions, number, isFirst, isLast, total, buttons };
+    const wizPropsToLayout = { actions, number, isFirst, isLast, total, buttons };
     const propsToComponent = { ...stepDetails, ...wizardStateManager };
 
     return (
       <span {...{className, style}}>
-        <Layout {...{[scopeKey]: propsToLayout}}>
+        <Layout {...{
+          ...parentLayoutProps,
+          ...layoutProps,
+          scopeKey,
+          [scopeKey]: wizPropsToLayout }}>
           <Cmp {...{
             ...componentProps,
             [scopeKey]: propsToComponent,
@@ -248,6 +254,7 @@ export class Wizard extends React.Component {
     const {
       children,
       layoutComponent,
+      layoutProps,
       scopeKey,
       wizardStateManager,
     } = this.props;
@@ -268,6 +275,7 @@ export class Wizard extends React.Component {
               ...kid.props,
               wizardStateManager,
               layoutComponent,
+              parentLayoutProps: layoutProps,
               scopeKey,
               stepDetails: this.makeNumber(i, wizardStateManager.total),
             }

--- a/src/WhateverWizard.js
+++ b/src/WhateverWizard.js
@@ -132,6 +132,7 @@ export class Step extends React.Component {
     componentProps: PT.object,
     layout: PT.func,
     layoutProps: PT.object,
+    parentLayoutProps: PT.object,
     wizardStateManager: PT.shape({
       active: PT.number,
       actions: PT.shape({}),

--- a/src/WhateverWizard.js
+++ b/src/WhateverWizard.js
@@ -131,6 +131,7 @@ export class Step extends React.Component {
     componentClass: PT.oneOfType([PT.func, PT.string]),
     componentProps: PT.object,
     layout: PT.func,
+    layoutProps: PT.object,
     wizardStateManager: PT.shape({
       active: PT.number,
       actions: PT.shape({}),
@@ -227,6 +228,7 @@ export class Wizard extends React.Component {
   static propTypes = {
     scopeKey: PT.string,
     layoutComponent: PT.func,
+    layoutProps: PT.object,
     wizardStateManager: PT.shape({
       active: PT.number,
       actions: PT.shape({}),

--- a/src/WhateverWizard.js
+++ b/src/WhateverWizard.js
@@ -203,7 +203,6 @@ export class Step extends React.Component {
     const propsToLayout = { actions, number, isFirst, isLast, total, buttons };
     const propsToComponent = { ...stepDetails, ...wizardStateManager };
 
-    debugger
     return (
       <span {...{className, style}}>
         <Layout {...{[scopeKey]: propsToLayout}}>

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Example from './Example2';
+import Example from './Example';
 import './index.css';
 
 ReactDOM.render(


### PR DESCRIPTION
- add a layout component prop to wizard
- move the render position of buttons from the lib to the user

Nonbreaking UI Changes:
- now provides a default layout. possible for double buttons